### PR TITLE
Keyboard hint pressed key

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,4 +1,5 @@
 import './App.css';
+import React from 'react'
 import { useCallback, useEffect, useState } from 'react';
 import MacKeyboard from './MacKeyboard';
 
@@ -7,12 +8,10 @@ function App() {
 
   const onKeyDown = useCallback((event) => {
     setCurrentKey(event.key);
-    event.stopPropagation();
   }, [currentKey])
 
   const onKeyUp = useCallback((event) => {
     setCurrentKey("");
-    event.stopPropagation();
   }, [currentKey]);
   
   useEffect(() => {
@@ -33,9 +32,18 @@ function App() {
 
   return (
     <div className="App">
-      <MacKeyboard pressedKey={currentKey}/>
+      <MacKeyboard pressedKey={currentKey} style={MacKeyboardStyle} />
     </div>
   );
 }
+
+const MacKeyboardStyle = {
+  position: 'absolute',
+  left: '8em',
+  top: '15em',
+  display: 'block',
+  width: '50em',
+  height: '18em',
+};
 
 export default App;

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -9,12 +9,25 @@ function App() {
     setCurrentKey(event.key);
     event.stopPropagation();
   }, [currentKey])
+
+  const onKeyUp = useCallback((event) => {
+    setCurrentKey("");
+    event.stopPropagation();
+  }, [currentKey]);
   
   useEffect(() => {
     document.body.addEventListener("keydown", onKeyDown);
 
     return () => {
       document.body.removeEventListener("keydown", onKeyDown);
+    }
+  })
+
+  useEffect(() => {
+    document.body.addEventListener("keyup", onKeyUp);
+
+    return () => {
+      document.body.addEventListener("keyup", onKeyUp);
     }
   })
 

--- a/front/src/MacKeyboard.js
+++ b/front/src/MacKeyboard.js
@@ -1,140 +1,110 @@
 import React from 'react';
 import Key from './Key';
+import MacKeyboardStyles from './MacKeyboard.styles';
 
-function MacKeyboard ( { pressedKey } ) {
-    // TODO: 인자로 넘어온 pressedKey의 색상을 다르게해서 표시하기.
-    console.log(pressedKey);
+function MacKeyboard ( { pressedKey, style } ) {
 
     return (
-        <div className="keyboard" style={MacKeyboardStyle}>
-            <div className="keyboard-row" style={KeyboardRowStyle}>
-                <Key value="~" customStyle={KeyDefaultStyle} />
-                <Key value="1" customStyle={KeyDefaultStyle} />
-                <Key value="2" customStyle={KeyDefaultStyle} />
-                <Key value="3" customStyle={KeyDefaultStyle} />
-                <Key value="4" customStyle={KeyDefaultStyle} />
-                <Key value="5" customStyle={KeyDefaultStyle} />
-                <Key value="7" customStyle={KeyDefaultStyle} />
-                <Key value="8" customStyle={KeyDefaultStyle} />
-                <Key value="9" customStyle={KeyDefaultStyle} />
-                <Key value="0" customStyle={KeyDefaultStyle} />
-                <Key value="-" customStyle={KeyDefaultStyle} />
-                <Key value="+" customStyle={KeyDefaultStyle} />
-                <Key value="Delete" customStyle={{...KeyDefaultStyle, ...KeyEscStyle}} />
+        <div className="keyboard" style={style}>
+            <div className="keyboard-row" style={MacKeyboardStyles.KeyboardRowStyle}>
+                <Key value="~" customStyle={getStyle('~', pressedKey)} />
+                <Key value="1" customStyle={getStyle('1', pressedKey)} />
+                <Key value="2" customStyle={getStyle('2', pressedKey)} />
+                <Key value="3" customStyle={getStyle('3', pressedKey)} />
+                <Key value="4" customStyle={getStyle('4', pressedKey)} />
+                <Key value="5" customStyle={getStyle('5', pressedKey)} />
+                <Key value="6" customStyle={getStyle('6', pressedKey)} />
+                <Key value="7" customStyle={getStyle('7', pressedKey)} />
+                <Key value="8" customStyle={getStyle('8', pressedKey)} />
+                <Key value="9" customStyle={getStyle('9', pressedKey)} />
+                <Key value="0" customStyle={getStyle('0', pressedKey)} />
+                <Key value="-" customStyle={getStyle('-', pressedKey)} />
+                <Key value="=" customStyle={getStyle('=', pressedKey)} />
+                <Key value="Delete" customStyle={getStyle('backspace', pressedKey)} />
             </div>
-            <div className="keyboard-row" style={KeyboardRowStyle}>
-                <Key value="tab" customStyle={{...KeyDefaultStyle, ...KeyEscStyle}} />
-                <Key value="q" customStyle={KeyDefaultStyle} />
-                <Key value="w" customStyle={KeyDefaultStyle} />
-                <Key value="e" customStyle={KeyDefaultStyle} />
-                <Key value="r" customStyle={KeyDefaultStyle} />
-                <Key value="t" customStyle={KeyDefaultStyle} />
-                <Key value="y" customStyle={KeyDefaultStyle} />
-                <Key value="u" customStyle={KeyDefaultStyle} />
-                <Key value="i" customStyle={KeyDefaultStyle} />
-                <Key value="o" customStyle={KeyDefaultStyle} />
-                <Key value="p" customStyle={KeyDefaultStyle} />
-                <Key value="[" customStyle={KeyDefaultStyle} />
-                <Key value="}" customStyle={KeyDefaultStyle} />
-                <Key value="\" customStyle={KeyDefaultStyle} />
+            <div className="keyboard-row" style={MacKeyboardStyles.KeyboardRowStyle}>
+                <Key value="Tab" customStyle={getStyle('tab', pressedKey)} />
+                <Key value="q" customStyle={getStyle('q', pressedKey)} />
+                <Key value="w" customStyle={getStyle('w', pressedKey)} />
+                <Key value="e" customStyle={getStyle('e', pressedKey)} />
+                <Key value="r" customStyle={getStyle('r', pressedKey)} />
+                <Key value="t" customStyle={getStyle('t', pressedKey)} />
+                <Key value="y" customStyle={getStyle('y', pressedKey)} />
+                <Key value="u" customStyle={getStyle('u', pressedKey)} />
+                <Key value="i" customStyle={getStyle('i', pressedKey)} />
+                <Key value="o" customStyle={getStyle('o', pressedKey)} />
+                <Key value="p" customStyle={getStyle('p', pressedKey)} />
+                <Key value="[" customStyle={getStyle('[', pressedKey)} />
+                <Key value="]" customStyle={getStyle(']', pressedKey)} />
+                <Key value="\" customStyle={getStyle('\\', pressedKey)} />
             </div>
-            <div className="keyboard-row" style={KeyboardRowStyle}>
-                <Key value="CAPS" customStyle={{...KeyDefaultStyle, ...KeyCapsLockStyle}} />
-                <Key value="a" customStyle={KeyDefaultStyle} />
-                <Key value="s" customStyle={KeyDefaultStyle} />
-                <Key value="d" customStyle={KeyDefaultStyle} />
-                <Key value="f" customStyle={KeyDefaultStyle} />
-                <Key value="g" customStyle={KeyDefaultStyle} />
-                <Key value="h" customStyle={KeyDefaultStyle} />
-                <Key value="j" customStyle={KeyDefaultStyle} />
-                <Key value="k" customStyle={KeyDefaultStyle} />
-                <Key value="l" customStyle={KeyDefaultStyle} />
-                <Key value=";" customStyle={KeyDefaultStyle} />
-                <Key value="'" customStyle={KeyDefaultStyle} />
-                <Key value="return" customStyle={{...KeyDefaultStyle, ...KeyReturnStyle}} />
+            <div className="keyboard-row" style={MacKeyboardStyles.KeyboardRowStyle}>
+                <Key value="CAPS" customStyle={getStyle('capslock', pressedKey)} />
+                <Key value="a" customStyle={getStyle('a', pressedKey)} />
+                <Key value="s" customStyle={getStyle('s', pressedKey)} />
+                <Key value="d" customStyle={getStyle('d', pressedKey)} />
+                <Key value="f" customStyle={getStyle('f', pressedKey)} />
+                <Key value="g" customStyle={getStyle('g', pressedKey)} />
+                <Key value="h" customStyle={getStyle('h', pressedKey)} />
+                <Key value="j" customStyle={getStyle('j', pressedKey)} />
+                <Key value="k" customStyle={getStyle('k', pressedKey)} />
+                <Key value="l" customStyle={getStyle('l', pressedKey)} />
+                <Key value=";" customStyle={getStyle(';', pressedKey)} />
+                <Key value="'" customStyle={getStyle("'", pressedKey)} />
+                <Key value="return" customStyle={getStyle("enter", pressedKey)} />
             </div>
-            <div className="keyboard-row" style={KeyboardRowStyle}>
-                <Key value="⇧" customStyle={{...KeyDefaultStyle, ...KeyShiftStyle}} />
-                <Key value="z" customStyle={KeyDefaultStyle} />
-                <Key value="x" customStyle={KeyDefaultStyle} />
-                <Key value="c" customStyle={KeyDefaultStyle} />
-                <Key value="v" customStyle={KeyDefaultStyle} />
-                <Key value="b" customStyle={KeyDefaultStyle} />
-                <Key value="n" customStyle={KeyDefaultStyle} />
-                <Key value="m" customStyle={KeyDefaultStyle} />
-                <Key value="," customStyle={KeyDefaultStyle} />
-                <Key value="." customStyle={KeyDefaultStyle} />
-                <Key value="/" customStyle={KeyDefaultStyle} />
-                <Key value="⇧" customStyle={{...KeyDefaultStyle, ...KeyShiftStyle}} />
+            <div className="keyboard-row" style={MacKeyboardStyles.KeyboardRowStyle}>
+                <Key value="⇧" customStyle={getStyle('shift', pressedKey)} />
+                <Key value="z" customStyle={getStyle('z', pressedKey)} />
+                <Key value="x" customStyle={getStyle('x', pressedKey)} />
+                <Key value="c" customStyle={getStyle('c', pressedKey)} />
+                <Key value="v" customStyle={getStyle('v', pressedKey)} />
+                <Key value="b" customStyle={getStyle('b', pressedKey)} />
+                <Key value="n" customStyle={getStyle('n', pressedKey)} />
+                <Key value="m" customStyle={getStyle('m', pressedKey)} />
+                <Key value="," customStyle={getStyle(',', pressedKey)} />
+                <Key value="." customStyle={getStyle('.', pressedKey)} />
+                <Key value="/" customStyle={getStyle('/', pressedKey)} />
+                <Key value="⇧" customStyle={getStyle('shift', pressedKey)} />
             </div>
-            <div className="keyboard-row" style={KeyboardRowStyle}>
-                <Key value="fn" customStyle={{...KeyDefaultStyle, ...KeySmallStyle}} />
-                <Key value="^" customStyle={{...KeyDefaultStyle, ...KeySmallStyle}} />
-                <Key value="⌥" customStyle={{...KeyDefaultStyle, ...KeySmallStyle}} />
-                <Key value="⌘" customStyle={{...KeyDefaultStyle, ...KeyCommandStyle}} />
-                <Key value="   " customStyle={{...KeyDefaultStyle, ...KeySpaceBarStyle}} />
-                <Key value="⌘" customStyle={{...KeyDefaultStyle, ...KeyCommandStyle}} />
-                <Key value="⌥" customStyle={{...KeyDefaultStyle, ...KeySmallStyle}} />
-                <Key value="<" customStyle={KeyDefaultStyle} />
-                <Key value="|" customStyle={KeyDefaultStyle} />
-                <Key value=">" customStyle={KeyDefaultStyle} />
+            <div className="keyboard-row" style={MacKeyboardStyles.KeyboardRowStyle}>
+                <Key value="fn" customStyle={getStyle('fn', pressedKey)} />
+                <Key value="^" customStyle={getStyle('control', pressedKey)} />
+                <Key value="⌥" customStyle={getStyle('alt', pressedKey)} />
+                <Key value="⌘" customStyle={getStyle('meta', pressedKey)} />
+                <Key value="   " customStyle={getStyle(' ', pressedKey)} />
+                <Key value="⌘" customStyle={getStyle('meta', pressedKey)} />
+                <Key value="⌥" customStyle={getStyle('alt', pressedKey)} />
+                <Key value="<" customStyle={getStyle('arrowleft', pressedKey)} />
+                <Key value="|" customStyle={getStyle('arrowdown', pressedKey)} />
+                <Key value=">" customStyle={getStyle('arrowright', pressedKey)} />
             </div>
         </div>
     )
 }
 
-const MacKeyboardStyle = {
-    backgroundColor: '#151515',
-    position: 'absolute',
-    left: '8em',
-    top: '15em',
-    display: 'block',
-    width: '50em',
-    height: '18em',
-};
+function getStyle(value, pressedKey) {
+    let retStyle = MacKeyboardStyles.KeyDefaultStyle;
+    getStyle.styleMap = {
+        'fn': MacKeyboardStyles.KeySmallStyle,
+        'control': MacKeyboardStyles.KeySmallStyle,
+        'alt': MacKeyboardStyles.KeySmallStyle,
+        'tab': MacKeyboardStyles.KeyEscStyle,
+        'backspace': MacKeyboardStyles.KeyEscStyle,
+        'capslock': MacKeyboardStyles.KeyCapsLockStyle,
+        ' ': MacKeyboardStyles.KeySpaceBarStyle,
+        'meta': MacKeyboardStyles.KeyCommandStyle,
+        'enter': MacKeyboardStyles.KeyReturnStyle,
+        'shift': MacKeyboardStyles.KeyShiftStyle,
+    }
 
-const KeyDefaultStyle = {
-    color: "#FB9FB1", // F5F5F5
-    width: '32px',
-};
+    retStyle = {...retStyle, ...getStyle.styleMap[value]};
+    pressedKey = pressedKey.toLowerCase();    
+    if (value === pressedKey) {
+        retStyle = {...retStyle, ...MacKeyboardStyles.KeyPressedStyle};
+    }
 
-const KeyPressedStyle = {
-    backgroundColor: '#505050', // bright black
-};
-
-const KeyEscStyle = {
-    width: '60px',
-    fontSize: '1.2em',
-};
-
-const KeyCapsLockStyle = {
-    width: '70px',
-    fontSize: '1.2em',
-};
-
-const KeyReturnStyle = {
-    width: '70px',
-    fontSize: '1.2em',
+    return retStyle;
 }
-
-const KeyShiftStyle = {
-    width: '80px',
-}
-
-const KeySpaceBarStyle = {
-    width: '300px',
-}
-
-const KeyCommandStyle = {
-    width: '45px',
-}
-
-const KeySmallStyle = {
-    width: '30px',
-}
-
-const KeyboardRowStyle = {
-    display: 'flex',
-};
 
 export default React.memo(MacKeyboard);

--- a/front/src/MacKeyboard.styles.js
+++ b/front/src/MacKeyboard.styles.js
@@ -1,0 +1,51 @@
+
+const KeyDefaultStyle = {
+    color: "#FB9FB1", // F5F5F5
+    width: '32px',
+};
+
+const KeyPressedStyle = {
+    backgroundColor: '#505050', // bright black
+    color: '#F5F5F5',
+};
+
+const KeyEscStyle = {
+    width: '60px',
+    fontSize: '1.2em',
+};
+
+const KeyCapsLockStyle = {
+    width: '70px',
+    fontSize: '1.2em',
+};
+
+const KeyReturnStyle = {
+    width: '70px',
+    fontSize: '1.2em',
+};
+
+const KeyShiftStyle = {
+    width: '80px',
+};
+
+const KeySpaceBarStyle = {
+    width: '300px',
+};
+
+const KeyCommandStyle = {
+    width: '45px',
+};
+
+const KeySmallStyle = {
+    width: '30px',
+};
+
+const KeyboardRowStyle = {
+    display: 'flex',
+};
+
+export default {
+    KeyDefaultStyle, KeyPressedStyle, KeyEscStyle, KeyCapsLockStyle,
+    KeyReturnStyle, KeyShiftStyle, KeySpaceBarStyle, KeyCommandStyle, KeySmallStyle,
+    KeyboardRowStyle,
+};


### PR DESCRIPTION
누르고있는 키보드를 표시한다.
누르던 키를 떼면 표시하지 않는다.
![MacKeyboard](https://user-images.githubusercontent.com/13645032/110306656-66271900-8041-11eb-98d1-2f31713e9552.gif)

디자인은 CSS파일 만들지 않고, MacKeyboard.styles.js 에 박아넣음.

this resolves #1 
